### PR TITLE
Explicit Permission GHA Workflow Pypi Publishing

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,6 +1,13 @@
 on:
   release:
     types: [released]
+permissions:
+  actions: read
+  contents: read
+  deployments: read
+  packages: none
+  pull-requests: write
+  security-events: write
 jobs:
   pypi-publish:
     name: Upload release to PyPI


### PR DESCRIPTION
Add permissions to GHA worflow from pypi publishing